### PR TITLE
Fix unresolved lightweight-charts import

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-chart-financial": "^0.2.1",
         "date-fns": "^4.1.0",
+        "lightweight-charts": "^4.2.3",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0"
@@ -1948,6 +1949,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fancy-canvas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fancy-canvas/-/fancy-canvas-2.1.0.tgz",
+      "integrity": "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2252,6 +2259,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightweight-charts": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/lightweight-charts/-/lightweight-charts-4.2.3.tgz",
+      "integrity": "sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fancy-canvas": "2.1.0"
       }
     },
     "node_modules/locate-path": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-financial": "^0.2.1",
     "date-fns": "^4.1.0",
-    "lightweight-charts": "^4.1.0",
+    "lightweight-charts": "^4.2.3",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0"


### PR DESCRIPTION
## Summary
- ensure lightweight-charts dependency is declared in frontend to prevent missing import errors

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892ca0f54848328a67d9e17fb3b939d